### PR TITLE
Fix attempting to core dump 100T of memory

### DIFF
--- a/compiler-rt/lib/msan/msan_linux.cpp
+++ b/compiler-rt/lib/msan/msan_linux.cpp
@@ -155,7 +155,7 @@ static bool InitShadow(bool init_origins, bool dry_run) {
       if (!dry_run &&
           !MmapFixedSuperNoReserve(start, size, kMemoryLayout[i].name))
         return false;
-      if (dry_run && common_flags()->use_madv_dontdump)
+      if (!dry_run && common_flags()->use_madv_dontdump)
         DontDumpShadowMemory(start, size);
     }
     if (protect) {


### PR DESCRIPTION
It seems that commit
https://github.com/llvm/llvm-project/commit/c2a57034eff048cd36c563c8e0051db3a70991b3 from upstream LLVM was cherry-picked slightly incorrectly. MADV_DONTNEED should have been used when _not_ executing a dry run.
